### PR TITLE
All lines in block comments should have extra space.

### DIFF
--- a/lib/jsdoc.js
+++ b/lib/jsdoc.js
@@ -30,7 +30,7 @@ function continueComments (editor) {
         editor.insertText(' * ');
         moveColumns = 3;
     } else if (previousLineText.match(blockComment)) {
-        editor.insertText('* ');
+        editor.insertText(' * ');
         moveColumns = 2;
     } else if (previousLineText.match(lineComment)) {
         editor.insertText('// ');


### PR DESCRIPTION
When adding a new line to a block comment the `*` is currently out dented because the first like is inside a block comment aligns itself with the previous line, but subsequent lines don't. Which means you end up with something like this:

``` js
/**
 *
*
 */
```

This pull request updates the `*` added on return within a block comment to have an extra space in front of it so that the comment continues to align properly and you get something like this:

``` js
/**
 *
 *
 */
```
